### PR TITLE
Fix duplicate imports and dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -101,9 +101,6 @@ dependencies {
 // Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")
 
-    // Damit du Zugriff auf Icons.Default.Schedule, Fastfood, CameraAlt etc. hast:
-    implementation("androidx.compose.material:material-icons-extended:1.5.0")
-
     // Compose Navigation
     implementation("androidx.navigation:navigation-compose:2.7.0")
 // evtl. für Charts (hier nur Canvas, keine extra Lib nötig)

--- a/app/src/main/java/com/example/diabetesapp/MainActivity.kt
+++ b/app/src/main/java/com/example/diabetesapp/MainActivity.kt
@@ -41,11 +41,6 @@ import com.example.diabetesapp.ui.theme.DiabetesAppTheme
 import kotlinx.coroutines.launch
 import java.util.Calendar
 import androidx.compose.material3.Button
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.Arrangement
 
 private enum class Screen { Calculation, Chart, Parameters }


### PR DESCRIPTION
## Summary
- clean up duplicate imports in `MainActivity`
- remove old material icons dependency version from the app module

## Testing
- `gradlew` could not run due to lack of network access

------
https://chatgpt.com/codex/tasks/task_e_684fe7263a5c83268c992802be6230d9